### PR TITLE
Adds x-show and x-transition:* variants for code snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,13 @@ IntelliSense for Alpine's directives.
 | x\-for\-index | `<template x-for="(${1:item}, ${2:index}) in ${3:items}" :key="$2"> $0 </template>` |
 | x\-bind:class | `x-bind:class="{ '${1:hidden}': ${2:foo} }"` |
 | x\-bind | `x-bind:${1:attribute}="${2:expression}"` |
+| x\-show | `x-show="$0"` |
+| x\-transition:enter | `x-transition:enter="$0"` |
+| x\-transition:enter-start | `x-transition:enter-start="$0"` |
+| x\-transition:enter-end | `x-transition:enter-end="$0"` |
+| x\-transition:leave | `x-transition:leave="$0"` |
+| x\-transition:leave-start | `x-transition:leave-start="$0"` |
+| x\-transition:leave-end | `x-transition:leave-end="$0"` |
 | $el | `$el` |
 | $refs | `$refs.${1:name}` |
 | $event | `$event` |

--- a/snippets/html.json
+++ b/snippets/html.json
@@ -44,6 +44,48 @@
         ],
         "description": "x-bind sets the value of an attribute to the result of a JavaScript expression. The expression has access to all the keys of the component's data object, and will update every-time its data is updated."
     },
+    "Alpine.js x-show": {
+      "prefix": "x-show",
+      "body": [
+        "x-show=\"$0\""
+      ]
+    },
+    "Alpine.js x-transition:enter": {
+      "prefix": "x-transition:enter",
+      "body": [
+        "x-transition:enter=\"$0\""
+      ]
+    },
+    "Alpine.js x-transition:enter-start": {
+      "prefix": "x-transition:enter-start",
+      "body": [
+        "x-transition:enter-start=\"$0\""
+      ]
+    },
+    "Alpine.js x-transition:enter-end": {
+      "prefix": "x-transition:enter-end",
+      "body": [
+        "x-transition:enter-end=\"$0\""
+      ]
+    },
+    "Alpine.js x-transition:leave": {
+      "prefix": "x-transition:leave",
+      "body": [
+        "x-transition:leave=\"$0\""
+      ]
+    },
+    "Alpine.js x-transition:leave-start": {
+      "prefix": "x-transition:leave-start",
+      "body": [
+        "x-transition:leave-start=\"$0\""
+      ]
+    },
+    "Alpine.js x-transition:leave-end": {
+      "prefix": "x-transition:leave-end",
+      "body": [
+        "x-transition:leave-end=\"$0\""
+      ]
+    },
     "Alpine.js $el": {
         "prefix": "$el",
         "body": [


### PR DESCRIPTION
I came across this after wanting to use Alpine.js and noticed that autocomplete for transitions and x-show were missing.﻿I added them locally, but I figured I'd open a PR as well.
